### PR TITLE
Remove generics from error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 embedded-hal = "1.0.0-rc.3"
 defmt = "0.3"
+thiserror-no-std = "2.0.2"
 
 [dev-dependencies]
 embedded-hal-mock = { version = "0.10.0-rc.3", features = ["eh1"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 
-embedded-hal = "1.0.0-rc.3"
+embedded-hal = { version = "1.0.0-rc.3", features = ["defmt-03"] }
 defmt = "0.3"
 thiserror-no-std = "2.0.2"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ pub struct KellerLD<I2C, D> {
     pub min_pressure: Option<f32>,
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Format)]
 pub enum KellerLDError {
     #[error("internal error")]
     UnexpectedValue,


### PR DESCRIPTION
Use `this-error` for more informative errors.